### PR TITLE
Add missing possible direction

### DIFF
--- a/index.html
+++ b/index.html
@@ -3554,7 +3554,7 @@ Good morning!
 				<li>The value of the &quot;line&quot; cue setting is the percentage value for the second coordinate of the origin attribute.<br/></li>
 				<li>The value of the &quot;position&quot; cue setting is the percentage value for the first coordinate of the origin attribute.</li>
 				</ul></li>
-				<li>If the block progression direction is left to right:
+				<li>If the block progression direction is left to right or right to left:
 
 				<ul>
 				<li>The value of the &quot;line&quot; cue setting is the percentage value for the first coordinate of the origin attribute.</li>


### PR DESCRIPTION
There is an unhandled case which is a block direction of right to left. I am not 100% sure if this is correct (not a huge vtt expert) but I think it should be handled like left to right as a block progression direction.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ChristianFeldmann/ttml-webvtt-mapping/pull/32.html" title="Last updated on Jul 7, 2022, 9:50 AM UTC (013f82f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ttml-webvtt-mapping/32/d8c3ecb...ChristianFeldmann:013f82f.html" title="Last updated on Jul 7, 2022, 9:50 AM UTC (013f82f)">Diff</a>